### PR TITLE
fix: pin summary-cards action to v0.10.2 (403 workaround)

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: vn7n24fzkq/github-profile-summary-cards@release
+      - uses: vn7n24fzkq/github-profile-summary-cards@v0.10.2
         env: # default use ${{ secrets.GITHUB_TOKEN }}, you can change to your personal access token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## 症状
`profile-summary-cards.yml` の `generate` ジョブが毎日 `AxiosError: Request failed with status code 403` で失敗（最後の成功 7/17 02:17、初失敗 7/18 02:03）。README.md 無し・`git add` 128 はその巻き添え。`github-metrics` ジョブは成功。

## 原因
上流 `vn7n24fzkq/github-profile-summary-cards@release` が 2026-07-16〜17 に fetch 周りを v0.11.x へ大改修（#299〜#304）。この回帰で 403 を返すようになった。タイミングが失敗開始と完全一致で、こちら側の設定は無関係。

## 対応
`@release` → 改修前最終タグ `@v0.10.2` に固定。1行変更・可逆。動く版に戻すだけ。もし v0.10.2 でも 403 が続くなら GitHub 側/token 問題と切り分けでき、その場合は PAT を `GITHUB_TOKEN` secret に入れる。

マージ後 Actions タブから手動 (`workflow_dispatch`) で1回流して確認するのが早いです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)