### PR TITLE
chore: clean up schedule cron to daily 02:00 UTC

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -1,8 +1,8 @@
 name: GitHub-Profile-Summary-Cards
 
 on:
-  schedule: # execute every 24 hours
-    - cron: '* */24 * * *'
+  schedule: # daily at 02:00 UTC (11:00 JST)
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`'* */24 * * *'` は「時=0のみ・分=毎分」で本来60回発火する雑な書式（GitHub が間引き/遅延させて実質日次になっている）。素直な日次書式 `'0 2 * * *'`（02:00 UTC = JST 11:00、今の実行時刻とほぼ一致）に置換。

挙動は実質変わらず（1日1回）、意図が読める書式になるだけ。失敗とは無関係のクリーンアップ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)