### PR TITLE
tidy(metrics): drop broken habits & achievements plugins

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -58,17 +58,8 @@ jobs:
           # repositories_skipped: piscon2019,piscon2019-2,go-traq
           use_prebuilt_image: yes
 
-          plugin_habits: yes
-          plugin_habits_charts: yes
-          plugin_habits_days: 14
-          plugin_habits_facts: yes
-          plugin_habits_from: 200
-
-          plugin_achievements: yes
-          plugin_achievements_display: compact
-          plugin_achievements_secrets: yes
-          plugin_achievements_threshold: C
-          plugin_achievements_ignored: deployer, gister, automator
-
+          # NOTE: plugin_habits and plugin_achievements removed — both error on the current
+          # GitHub GraphQL schema (habits: TypeError 'author' of undefined; achievements:
+          # GraphqlResponseError) and lowlighter/metrics is archived, so there's no upstream fix.
           plugin_isocalendar: yes
           plugin_isocalendar_duration: half-year


### PR DESCRIPTION
## 症状
最新 run (#29681264030) の `github-metrics` ジョブは success 表示だが annotations に **2 error(s)**。これが metrics2.svg で「表示されていないセクション」の正体：

```
achievements: GraphqlResponseError (GitHub GraphQL のスキーマ変化)
habits: TypeError: Cannot destructure property 'author' of undefined
```

`lowlighter/metrics` は **archived**（メンテ終了）なのでどちらも upstream 修正は来ない。

## 変更
metrics2 から壊れている `plugin_habits` と `plugin_achievements` を除去。動作している `plugin_isocalendar` は維持。metrics1（languages / lines / notable / activity）は元々クリーンなので変更なし。

これで metrics2.svg のエラーセクションが消える。

---
### 補足: summary-cards（別件）について
最新 `v0.11.6` を実際にライブ実行して確認したところ、**このアカウントでは復活困難**でした：
- デフォルト `GITHUB_TOKEN`: 5枚中4枚が 403（repoスコープでユーザー横断クエリ不可）。
- `METRICS_TOKEN`(PAT): 403 + `Resource limits for this query exceeded` で 0枚。

アカウント規模が大きく重いGraphQLクエリがコスト上限に当たる構造問題（上流 #301–306 が firefighting 中）。**hosted な github-readme-stats（現状 master で稼働中）を維持推奨**。どうしても summary-cards を使いたい場合は classic PAT (`read:user`+`repo`) ＋ レート回復待ちが必要だが、resource-limit は残る可能性が高い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)