### PR TITLE
プロフィールカードを堅牢化：raw URL修正 + 死んだ外部サービス撤去 + 自前stats card

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ Here are some ideas to get you started:
 ## Fujiya's GitHub
 
 <div>
-  <img src="https://github.com/fujiya228/fujiya228/blob/master/metrics1.svg" width="48%" />
-  <img src="https://github.com/fujiya228/fujiya228/blob/master/metrics2.svg" width="48%" />
-</div>
-
-<div>
-  <img src="https://github-readme-stats.vercel.app/api?username=fujiya228&show_icons=true&theme=github_dark" width="48%" />
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=fujiya228&layout=compact&theme=github_dark" width="48%" />
+  <img src="https://raw.githubusercontent.com/fujiya228/fujiya228/master/metrics1.svg" width="48%" />
+  <img src="https://raw.githubusercontent.com/fujiya228/fujiya228/master/metrics2.svg" width="48%" />
 </div>
 


### PR DESCRIPTION
プロフィールのカードが表示されない問題を根治し、二度と第三者サービスで壊れない構成にする。

## 表示されなかった原因（2つ）
1. **metrics の img URL**: `github.com/.../blob/...svg` は `text/html` を返すため `<img>` で描画不可（既存バグ）。→ `raw.githubusercontent.com/...`（`image/svg+xml`）へ。
2. **github-readme-stats 公開インスタンス停止**: `DEPLOYMENT_PAUSED`（HTTP 503）。→ 撤去。

## 追加：自前 stats カード（`stats.svg`）
第三者ライブサービスに依存しない自前生成に置き換え：
- `.github/scripts/generate-stats.mjs` … 依存ゼロの Node スクリプト。軽い GraphQL クエリ → SVG 描画 → commit。
- `.github/workflows/stats-card.yml` … 日次（02:15 UTC、metrics とずらして push 競合回避）＋手動実行。
- 初回 `stats.svg` はコミット済みなのでマージ直後から表示される。

### なぜ summary-cards / github-readme-stats でなく自前か
- summary-cards は言語別コミット走査が重く、このアカウントで `RESOURCE_LIMITS_EXCEEDED`。公開 readme-stats はインスタンス停止。
- このアカウントは PR 2282 / issue 2266 と履歴が大きく、`pullRequests`/`issues`/`contributions` の totalCount ですら個別に重い。→ **メトリクスごとに小さなクエリへ分割**し、単発失敗は `—` にフォールバック（カード全体は落ちない）。
- 出力は commit 済み SVG を raw URL で配信＝**停止・レート制限・deprecate される外部依存ゼロ**。

## マージ後の表示
- metrics1（header/activity/repos/languages/lines/notable）
- metrics2（isocalendar）
- stats.svg（Stars/Commits(1y)/PRs/Followers/Repos/Issues＋上位言語バー）

※ `stats-card.yml` は既存の `METRICS_TOKEN`(PAT) を使用（デフォルト `GITHUB_TOKEN` はユーザー横断クエリで403のため）。新規 secret 不要。

プレビュー: https://raw.githubusercontent.com/fujiya228/fujiya228/fix-profile-rendering/stats.svg

🤖 Generated with [Claude Code](https://claude.com/claude-code)