### PR TITLE
feat: 自前生成の stats カード（外部ライブサービス非依存）

### DIFF
--- a/.github/scripts/generate-stats.mjs
+++ b/.github/scripts/generate-stats.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// Self-generated GitHub stats card. One cheap GraphQL query -> SVG -> committed to the repo.
+// No third-party live service (nothing to get paused/rate-limited), and the query is light
+// enough to avoid the "Resource limits for this query exceeded" that killed summary-cards.
+//
+// Usage:  GITHUB_TOKEN=<pat> node generate-stats.mjs <login> [outfile]
+//         node generate-stats.mjs --selftest        # offline render check, no network
+
+const THEME = {
+  bg: '#0d1117', border: '#30363d', title: '#58a6ff',
+  label: '#8b949e', value: '#c9d1d9', track: '#21262d',
+};
+
+const fmt = (n) => (n == null ? '—' : n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n));
+const esc = (s) => String(s).replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+
+async function gql(token, query, variables) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { Authorization: `bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  if (json.errors) throw new Error('GraphQL: ' + JSON.stringify(json.errors));
+  return json.data;
+}
+
+// This account is large enough that pullRequests/issues/contributions totalCounts are each
+// expensive — combined in one query they trip GitHub's RESOURCE_LIMITS_EXCEEDED. So every
+// metric is its own small query and any single failure degrades to null (rendered as "—")
+// instead of failing the whole card.
+async function safe(token, field, query, pick) {
+  try {
+    return pick(await gql(token, query, { login: LOGIN }));
+  } catch (e) {
+    console.warn(`skip ${field}: ${e.message.slice(0, 120)}`);
+    return null;
+  }
+}
+
+let LOGIN;
+async function fetchStats(login, token) {
+  LOGIN = login;
+  // core query: name + followers + repo nodes for stars & languages (bounded at 100 repos)
+  const core = await gql(token, `query($login:String!){user(login:$login){
+      name login followers{totalCount}
+      repositories(first:100, ownerAffiliations:OWNER, isFork:false, orderBy:{field:STARGAZERS,direction:DESC}){
+        totalCount nodes{ stargazerCount languages(first:8, orderBy:{field:SIZE,direction:DESC}){ edges{ size node{ name color } } } } }
+    }}`, { login });
+  const u = core.user;
+  const repos = u.repositories.nodes;
+  // ponytail: stars/langs aggregate the top-100 repos by stars; >100 repos slightly undercounts
+  // the long tail — fine for a profile card, bump `first:` if it ever matters.
+  const stars = repos.reduce((s, r) => s + r.stargazerCount, 0);
+  const langBytes = {};
+  for (const r of repos)
+    for (const e of r.languages.edges) {
+      const k = e.node.name;
+      langBytes[k] = langBytes[k] || { size: 0, color: e.node.color || '#888' };
+      langBytes[k].size += e.size;
+    }
+  const total = Object.values(langBytes).reduce((s, l) => s + l.size, 0) || 1;
+  const langs = Object.entries(langBytes)
+    .sort((a, b) => b[1].size - a[1].size)
+    .slice(0, 6)
+    .map(([name, l]) => ({ name, color: l.color, pct: (l.size / total) * 100 }));
+
+  const [commits, prs, issues] = await Promise.all([
+    safe(token, 'commits', `query($login:String!){user(login:$login){contributionsCollection{totalCommitContributions}}}`, (d) => d.user.contributionsCollection.totalCommitContributions),
+    safe(token, 'prs', `query($login:String!){user(login:$login){pullRequests{totalCount}}}`, (d) => d.user.pullRequests.totalCount),
+    safe(token, 'issues', `query($login:String!){user(login:$login){issues{totalCount}}}`, (d) => d.user.issues.totalCount),
+  ]);
+
+  return {
+    name: u.name || u.login,
+    stars, commits, prs, issues,
+    followers: u.followers.totalCount,
+    repos: u.repositories.totalCount,
+    langs,
+  };
+}
+
+function renderSVG(s) {
+  const W = 500, H = 210;
+  const rows = [
+    ['Total Stars Earned', s.stars],
+    ['Total Commits (1y)', s.commits],
+    ['Total PRs', s.prs],
+  ];
+  const rows2 = [
+    ['Followers', s.followers],
+    ['Public Repos', s.repos],
+    ['Total Issues', s.issues],
+  ];
+  const statRow = (x, [label, val], i) => `
+    <text x="${x}" y="${86 + i * 26}" fill="${THEME.label}" font-size="13">${label}</text>
+    <text x="${x + 200}" y="${86 + i * 26}" fill="${THEME.value}" font-size="14" font-weight="600" text-anchor="end">${fmt(val)}</text>`;
+
+  // stacked language bar
+  const barX = 30, barW = W - 60, barY = 178;
+  let acc = 0;
+  const segs = s.langs.map((l) => {
+    const w = (l.pct / 100) * barW;
+    const seg = `<rect x="${barX + acc}" y="${barY}" width="${w.toFixed(1)}" height="8" fill="${l.color}"/>`;
+    acc += w;
+    return seg;
+  }).join('');
+  const legend = s.langs.map((l, i) => {
+    const lx = barX + i * 78;
+    return `<circle cx="${lx + 4}" cy="${barY + 24}" r="4" fill="${l.color}"/>
+      <text x="${lx + 13}" y="${barY + 28}" fill="${THEME.label}" font-size="10">${esc(l.name)} ${l.pct.toFixed(1)}%</text>`;
+  }).join('');
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Ubuntu, sans-serif">
+  <rect x="0.5" y="0.5" width="${W - 1}" height="${H - 1}" rx="10" fill="${THEME.bg}" stroke="${THEME.border}"/>
+  <text x="30" y="42" fill="${THEME.title}" font-size="18" font-weight="700">${esc(s.name)}'s GitHub stats</text>
+  ${rows.map((r, i) => statRow(30, r, i)).join('')}
+  ${rows2.map((r, i) => statRow(265, r, i)).join('')}
+  <rect x="${barX}" y="${barY}" width="${barW}" height="8" rx="4" fill="${THEME.track}"/>
+  ${segs}
+  ${legend}
+</svg>`;
+}
+
+// ---- self-test: offline render, no network ----
+if (process.argv.includes('--selftest')) {
+  const svg = renderSVG({
+    name: 'Test', stars: 1234, commits: 5678, prs: 90, issues: 12, followers: 345, repos: 67,
+    langs: [{ name: 'Go', color: '#00ADD8', pct: 60 }, { name: 'TypeScript', color: '#3178c6', pct: 40 }],
+  });
+  const ok = svg.includes("Test's GitHub stats") && svg.includes('1.2k') && svg.includes('#00ADD8');
+  console.log(ok ? 'selftest OK' : 'selftest FAILED');
+  process.exit(ok ? 0 : 1);
+}
+
+const [login, outfile = 'stats.svg'] = process.argv.slice(2);
+const token = process.env.GITHUB_TOKEN;
+if (!login || !token) {
+  console.error('usage: GITHUB_TOKEN=<pat> node generate-stats.mjs <login> [outfile]');
+  process.exit(1);
+}
+const stats = await fetchStats(login, token);
+const { writeFileSync } = await import('node:fs');
+writeFileSync(outfile, renderSVG(stats));
+console.log(`wrote ${outfile}:`, JSON.stringify({ ...stats, langs: stats.langs.map((l) => l.name) }));

--- a/.github/workflows/stats-card.yml
+++ b/.github/workflows/stats-card.yml
@@ -1,0 +1,31 @@
+name: Stats Card
+
+on:
+  schedule: # daily at 02:15 UTC — offset from the metrics workflow to avoid a push race
+    - cron: '15 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate stats.svg
+        env:
+          # PAT: the default repo-scoped GITHUB_TOKEN 403s on cross-repo user queries
+          GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN }}
+        run: node .github/scripts/generate-stats.mjs "${{ github.repository_owner }}" stats.svg
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet stats.svg; then
+            git add stats.svg
+            git commit -m "chore: refresh stats.svg [skip ci]"
+            git pull --rebase --autostash
+            git push
+          else
+            echo "stats.svg unchanged"
+          fi

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Here are some ideas to get you started:
   <img src="https://raw.githubusercontent.com/fujiya228/fujiya228/master/metrics2.svg" width="48%" />
 </div>
 
+<img src="https://raw.githubusercontent.com/fujiya228/fujiya228/master/stats.svg" width="60%" />
+

--- a/stats.svg
+++ b/stats.svg
@@ -1,0 +1,27 @@
+<svg width="500" height="210" viewBox="0 0 500 210" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Ubuntu, sans-serif">
+  <rect x="0.5" y="0.5" width="499" height="209" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <text x="30" y="42" fill="#58a6ff" font-size="18" font-weight="700">Yoshida Syunsuke's GitHub stats</text>
+  
+    <text x="30" y="86" fill="#8b949e" font-size="13">Total Stars Earned</text>
+    <text x="230" y="86" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">5</text>
+    <text x="30" y="112" fill="#8b949e" font-size="13">Total Commits (1y)</text>
+    <text x="230" y="112" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">168</text>
+    <text x="30" y="138" fill="#8b949e" font-size="13">Total PRs</text>
+    <text x="230" y="138" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">2.3k</text>
+  
+    <text x="265" y="86" fill="#8b949e" font-size="13">Followers</text>
+    <text x="465" y="86" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">18</text>
+    <text x="265" y="112" fill="#8b949e" font-size="13">Public Repos</text>
+    <text x="465" y="112" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">129</text>
+    <text x="265" y="138" fill="#8b949e" font-size="13">Total Issues</text>
+    <text x="465" y="138" fill="#c9d1d9" font-size="14" font-weight="600" text-anchor="end">2.3k</text>
+  <rect x="30" y="178" width="440" height="8" rx="4" fill="#21262d"/>
+  <rect x="30" y="178" width="240.9" height="8" fill="#3178c6"/><rect x="270.9083662154959" y="178" width="71.3" height="8" fill="#e34c26"/><rect x="342.20567932591774" y="178" width="35.1" height="8" fill="#3572A5"/><rect x="377.3307416057187" y="178" width="30.7" height="8" fill="#4F5D95"/><rect x="408.0600536824831" y="178" width="15.5" height="8" fill="#f1e05a"/><rect x="423.5417795610896" y="178" width="12.8" height="8" fill="#663399"/>
+  <circle cx="34" cy="202" r="4" fill="#3178c6"/>
+      <text x="43" y="206" fill="#8b949e" font-size="10">TypeScript 54.8%</text><circle cx="112" cy="202" r="4" fill="#e34c26"/>
+      <text x="121" y="206" fill="#8b949e" font-size="10">HTML 16.2%</text><circle cx="190" cy="202" r="4" fill="#3572A5"/>
+      <text x="199" y="206" fill="#8b949e" font-size="10">Python 8.0%</text><circle cx="268" cy="202" r="4" fill="#4F5D95"/>
+      <text x="277" y="206" fill="#8b949e" font-size="10">PHP 7.0%</text><circle cx="346" cy="202" r="4" fill="#f1e05a"/>
+      <text x="355" y="206" fill="#8b949e" font-size="10">JavaScript 3.5%</text><circle cx="424" cy="202" r="4" fill="#663399"/>
+      <text x="433" y="206" fill="#8b949e" font-size="10">CSS 2.9%</text>
+</svg>


### PR DESCRIPTION
PR #6 が私の stats カード追加コミットの反映前にマージされたため、その分を単独 PR として入れ直すもの。#6 で入った raw URL 修正・死んだ github-readme-stats 撤去はそのまま活きている。

## 追加内容
- `.github/scripts/generate-stats.mjs` … 依存ゼロの Node スクリプト。軽い GraphQL クエリ → SVG 描画 → `stats.svg` を出力。
- `.github/workflows/stats-card.yml` … 日次（02:15 UTC、metrics とずらして push 競合回避）＋手動実行。`METRICS_TOKEN` 使用（新規 secret 不要）。
- `stats.svg` … 初回分をコミット済み → マージ直後から表示。
- README に stats カードを追加。

## なぜ自前か（このアカウント固有の理由）
PR 2282 / issue 2266 と履歴が巨大で、`pullRequests`/`issues`/`contributions` の totalCount ですら個別に `RESOURCE_LIMITS_EXCEEDED` を誘発する（summary-cards が死んだ根本原因）。対策として **メトリクスごとに小クエリへ分割**し、単発失敗は `—` にフォールバック（カード全体は落ちない）。出力は commit 済み SVG を raw URL 配信＝**停止・レート制限・deprecate される外部依存ゼロ**。

実データ生成確認済み: Stars 5 / Commits(1y) 168 / PRs 2282 / Followers 18 / Repos 129 / Issues 2266、上位言語 TS・HTML・Python・PHP・JS・CSS。SVG は well-formed 検証済み、スクリプトにオフライン self-test 同梱。

プレビュー: https://raw.githubusercontent.com/fujiya228/fujiya228/stats-card/stats.svg

🤖 Generated with [Claude Code](https://claude.com/claude-code)